### PR TITLE
Convert catpcha to lower case improve robustness

### DIFF
--- a/api/captcha.ts
+++ b/api/captcha.ts
@@ -9,7 +9,7 @@ module.exports = async (req: NowRequest, res: NowResponse) => {
     const connection = await connect();
     var captcha = svgCaptcha.create({
       size: 4,
-      ignoreChars: "0oO1iLl",
+      ignoreChars: "0oO1iLlI",
       noise: 3
     });
 

--- a/api/submission.ts
+++ b/api/submission.ts
@@ -16,7 +16,10 @@ module.exports = async (req: NowRequest, res: NowResponse) => {
       captchaRepository
         .findOne(req.body.captcha.id)
         .then(async (captcha: Captcha) => {
-          if (captcha.text === req.body.captcha.answer) {
+          if (
+            captcha.text.toLocaleLowerCase() ===
+            req.body.captcha.answer.toLocaleLowerCase()
+          ) {
             const zipcode = req.body.submission.zipcode;
             const submissionRepository = connection.getRepository(Submission);
 


### PR DESCRIPTION
[minor fix] Convert catpcha to lower case improve robustness: 
![image](https://user-images.githubusercontent.com/22340670/79044031-27a39700-7c03-11ea-9de5-cff72d071239.png)
